### PR TITLE
Add calendar endpoint and fix Employee DB table

### DIFF
--- a/vacation-planner-pro/src/main/java/UlsterCS250/entities/JHalfDay.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/entities/JHalfDay.java
@@ -1,5 +1,6 @@
 package UlsterCS250.entities;
 
+import java.util.ArrayList;
 import java.util.Date;
 
 public class JHalfDay {
@@ -9,6 +10,7 @@ public class JHalfDay {
     private Date startDate;
     private Date endDate;
     private boolean isWorkDay;
+    private ArrayList<JEmployeeTimeOff> employeeTimeOffs;
 
     public JHalfDay(int id, boolean isAm, int dayOfWeekId, Date startDate, Date endDate, boolean isWorkDay) {
         this.id = id;
@@ -17,6 +19,17 @@ public class JHalfDay {
         this.startDate = startDate;
         this.endDate = endDate;
         this.isWorkDay = isWorkDay;
+        this.employeeTimeOffs = new ArrayList<>();
+    }
+
+    public JHalfDay(int id, boolean isAm, int dayOfWeekId, Date startDate, Date endDate, boolean isWorkDay, ArrayList<JEmployeeTimeOff> employeeTimeOffs) {
+        this.id = id;
+        this.isAm = isAm;
+        this.dayOfWeekId = dayOfWeekId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.isWorkDay = isWorkDay;
+        this.employeeTimeOffs = new ArrayList<>(employeeTimeOffs);
     }
 
     public int getId() {
@@ -65,5 +78,13 @@ public class JHalfDay {
 
     public void setWorkDay(boolean workDay) {
         isWorkDay = workDay;
+    }
+
+    public ArrayList<JEmployeeTimeOff> getEmployeeTimeOffs() {
+        return employeeTimeOffs;
+    }
+
+    private void setEmployeeTimeOffs(ArrayList<JEmployeeTimeOff> timeOff) {
+        this.employeeTimeOffs = new ArrayList<>(timeOff);
     }
 }

--- a/vacation-planner-pro/src/main/java/UlsterCS250/producers/RepositoryProducer.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/producers/RepositoryProducer.java
@@ -2,6 +2,7 @@ package UlsterCS250.producers;
 
 import UlsterCS250.repository.EmployeeTimeOffRepository;
 import UlsterCS250.repository.ToFixEmployeeRepository;
+import UlsterCS250.repository.VacationDayRepository;
 import UlsterCS250.repository.EmployeeRepository;
 //import UlsterCS250.repository.EmployeeTimeOffRepository;
 import UlsterCS250.repository.HalfDayRepository;
@@ -32,5 +33,11 @@ public class RepositoryProducer {
     @ApplicationScoped
     public HalfDayRepository produceHalfDayRepository() {
         return new HalfDayRepository();
+    }
+
+    @Produces
+    @ApplicationScoped
+    public VacationDayRepository produceVacationDayRepository() {
+        return new VacationDayRepository();
     }
 }

--- a/vacation-planner-pro/src/main/java/UlsterCS250/repository/EmployeeRepository.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/repository/EmployeeRepository.java
@@ -99,7 +99,7 @@ public class EmployeeRepository {
         }
         try {
             Connection conn = DriverManager.getConnection(dbUrl, user, pass);
-            PreparedStatement stmt = conn.prepareStatement("INSERT INTO Employees (username, password_hash, email, first_name, last_name, is_manager, is_active, last_login, created_at, department_id, years_of_service) VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?, ?)");
+            PreparedStatement stmt = conn.prepareStatement("INSERT INTO Employees (username, password_hash, email, first_name, last_name, is_manager, is_active, last_login, create_time, years_of_service) VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)");
             stmt.setString(1, employee.getUsername());
             stmt.setString(2, employee.getPassword());
             stmt.setString(3, employee.getEmail());
@@ -108,7 +108,6 @@ public class EmployeeRepository {
             stmt.setBoolean(6, false);
             stmt.setBoolean(7, true);
             stmt.setInt(8, 1);
-            stmt.setInt(9, 1);
             int rowsInserted = stmt.executeUpdate();
             if (rowsInserted > 0) LOGGER.info("Employee added successfully");
             else LOGGER.warning("Failed to add employee");

--- a/vacation-planner-pro/src/main/java/UlsterCS250/repository/EmployeeRepository.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/repository/EmployeeRepository.java
@@ -3,7 +3,7 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.logging.*;
 import UlsterCS250.entities.JEmployee;
-import UlsterCS250.viewModels.EmployeeVM;
+import UlsterCS250.requests.EmployeeVM;
 
 public class EmployeeRepository {
     private static String dbUrl = "jdbc:postgresql://localhost:5432/auth_database";

--- a/vacation-planner-pro/src/main/java/UlsterCS250/repository/ToFixEmployeeRepository.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/repository/ToFixEmployeeRepository.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.logging.*;
 import UlsterCS250.entities.JEmployee;
 import UlsterCS250.producers.RepositoryProducer;
-import UlsterCS250.viewModels.EmployeeVM;
+import UlsterCS250.requests.EmployeeVM;
 
 public class ToFixEmployeeRepository {
     /*

--- a/vacation-planner-pro/src/main/java/UlsterCS250/repository/VacationDayRepository.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/repository/VacationDayRepository.java
@@ -1,0 +1,118 @@
+package UlsterCS250.repository;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import UlsterCS250.entities.JEmployeeTimeOff;
+import UlsterCS250.entities.JHalfDay;
+import UlsterCS250.responses.CalendarDay;
+
+public class VacationDayRepository {
+    private static String dbUrl = "jdbc:postgresql://localhost:5432/auth_database";
+    private static String user = "vcpp";
+    private static String pass = "abc123";
+    private static final Logger LOGGER = Logger.getLogger(VacationDayRepository.class.getName());
+
+    public List<CalendarDay> getDays() {
+        List<CalendarDay> days = new ArrayList<>();
+        int calIndex = 0;
+
+        try (Connection conn = DriverManager.getConnection(dbUrl, user, pass);
+            PreparedStatement stmt = conn.prepareStatement("SELECT DISTINCT start_date FROM HalfDays")) {
+            ResultSet rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                Date date = rs.getDate("start_date");
+                List<JHalfDay> day = new ArrayList<>();
+                day.add(getHalfDay(date, true));
+                day.add(getHalfDay(date, false));
+                CalendarDay newDay = new CalendarDay(calIndex, date, day);
+                days.add(newDay);
+                calIndex++;
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return days;
+    }
+
+    private JHalfDay getHalfDay(Date date, boolean isAM) {
+        try (Connection conn = DriverManager.getConnection(dbUrl, user, pass);
+             PreparedStatement stmt = conn.prepareStatement("SELECT half_day_id, is_am, day_of_week_id, start_date, end_date, is_work_day FROM HalfDays WHERE start_date = ? AND is_am = ?")) {
+            stmt.setDate(1, date);
+            stmt.setBoolean(2, isAM);
+            ResultSet rs = stmt.executeQuery();
+
+            if (rs.next()) {
+                int halfDayId = rs.getInt("half_day_id");
+                boolean isAMHalf = rs.getBoolean("is_am");
+                int dayOfWeekId = rs.getInt("day_of_week_id");
+                Date startDate = rs.getDate("start_date");
+                Date endDate = rs.getDate("end_date");
+                boolean isWorkDay = rs.getBoolean("is_work_day");
+
+                ArrayList<JEmployeeTimeOff> employeeTimeOffs = getEmployeeTimeOffs(halfDayId);
+                String size = Integer.toString(employeeTimeOffs.size());
+                LOGGER.log(Level.SEVERE, size);
+                return new JHalfDay(halfDayId, isAMHalf, dayOfWeekId, startDate, endDate, isWorkDay, employeeTimeOffs);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    private ArrayList<JEmployeeTimeOff> getEmployeeTimeOffs(int halfDayId) {
+        ArrayList<JEmployeeTimeOff> employeeTimeOffs = new ArrayList<>();
+
+        try (Connection conn = DriverManager.getConnection(dbUrl, user, pass);
+             PreparedStatement stmt = conn.prepareStatement("SELECT employee_time_off_id, employee_id, half_day_id, reason FROM EmployeeTimeOffs WHERE half_day_id = ?")) {
+            stmt.setInt(1, halfDayId);
+            ResultSet rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                int timeOffId = rs.getInt("employee_time_off_id");
+                int employeeId = rs.getInt("employee_id");
+                int nhalfDayId = rs.getInt("half_day_id");
+                String reason = rs.getString("reason");
+                LOGGER.log(Level.SEVERE, reason);
+                employeeTimeOffs.add(new JEmployeeTimeOff(timeOffId, employeeId, nhalfDayId, reason));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return employeeTimeOffs;
+    }
+
+    public List<CalendarDay> getDaysForMonthAndYear(int month, int year) {
+        List<CalendarDay> days = new ArrayList<>();
+        int calIndex = 0;
+
+        try (Connection conn = DriverManager.getConnection(dbUrl, user, pass);
+             PreparedStatement stmt = conn.prepareStatement("SELECT DISTINCT start_date FROM HalfDays WHERE EXTRACT(MONTH FROM start_date) = ? AND EXTRACT(YEAR FROM start_date) = ?")) {
+            stmt.setInt(1, month);
+            stmt.setInt(2, year);
+            ResultSet rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                Date date = rs.getDate("start_date");
+                List<JHalfDay> halfDays = new ArrayList<>();
+                halfDays.add(getHalfDay(date, true));
+                halfDays.add(getHalfDay(date, false));
+                CalendarDay newDay = new CalendarDay(calIndex, date, halfDays);
+                days.add(newDay);
+                calIndex++;
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return days;
+    }
+}

--- a/vacation-planner-pro/src/main/java/UlsterCS250/requests/EmployeeVM.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/requests/EmployeeVM.java
@@ -1,4 +1,4 @@
-package UlsterCS250.viewModels;
+package UlsterCS250.requests;
 
 public class EmployeeVM {
 

--- a/vacation-planner-pro/src/main/java/UlsterCS250/responses/CalendarDay.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/responses/CalendarDay.java
@@ -1,0 +1,39 @@
+package UlsterCS250.responses;
+
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import UlsterCS250.entities.JHalfDay;
+
+public class CalendarDay {
+    private int id;
+    private final List<JHalfDay> halfDays;
+    private Date day;
+
+    public CalendarDay() {
+        this.halfDays = new ArrayList<>();
+    }
+
+    public CalendarDay(int id, Date day, List<JHalfDay> halfDays) {
+        this.id = id;
+        this.day = day;
+        this.halfDays = new ArrayList<>(halfDays);
+    }
+
+    public int getId() {
+        return this.id;
+    }
+
+    public Date getDay() {
+        return this.day;
+    }
+
+    public List<JHalfDay> getHalfDays() {
+        return Collections.unmodifiableList(halfDays);
+    }
+
+    public void addHalfDay(JHalfDay halfDay) {
+        this.halfDays.add(halfDay);
+    }
+}

--- a/vacation-planner-pro/src/main/java/UlsterCS250/rest/CalendarResource.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/rest/CalendarResource.java
@@ -1,0 +1,95 @@
+package UlsterCS250.rest;
+
+import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+
+import UlsterCS250.repository.VacationDayRepository;
+import UlsterCS250.responses.CalendarDay;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/calendar")
+public class CalendarResource {
+
+    @Inject
+    private VacationDayRepository vacationDayRepository;
+
+    
+    /* 
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @APIResponses(
+         value = {
+            @APIResponse(
+                 responseCode = "404",
+                 description = "No days found"),
+            @APIResponse(
+                 responseCode = "200",
+                 description = "Success"),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error")})
+    public Response getCalendar() {
+        try {
+            List<CalendarDay> days = vacationDayRepository.getDays();
+            if (days.isEmpty()) {
+                return Response.status(Response.Status.NOT_FOUND)
+                    .entity("No days found")
+                    .build();
+            }
+            return Response.ok(days).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity("Error retrieving days: " + e.getMessage())
+                .build();
+        }
+    }*/
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @APIResponses(
+         value = {
+            @APIResponse(
+                 responseCode = "400",
+                 description = "Invalid month"),
+            @APIResponse(
+                 responseCode = "404",
+                 description = "No days found"),
+            @APIResponse(
+                 responseCode = "200",
+                 description = "Success"),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal server error")})
+    public Response getMonthCalendar(
+        @QueryParam("month") int month,
+        @QueryParam("year") int year
+    ) {
+        try {
+            if (month < 1 || month > 12) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Invalid month value. Month should be between 1 and 12.")
+                    .build();
+            }
+
+            List<CalendarDay> days = vacationDayRepository.getDaysForMonthAndYear(month, year);
+            if (days.isEmpty()) {
+                return Response.status(Response.Status.NOT_FOUND)
+                    .entity("No days found for the specified month and year.")
+                    .build();
+            }
+            return Response.ok(days).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity("Error retrieving days: " + e.getMessage())
+                .build();
+        }
+    }
+    
+}

--- a/vacation-planner-pro/src/main/java/UlsterCS250/rest/EmployeeResource.java
+++ b/vacation-planner-pro/src/main/java/UlsterCS250/rest/EmployeeResource.java
@@ -2,7 +2,7 @@ package UlsterCS250.rest;
 
 import UlsterCS250.entities.JEmployee;
 import UlsterCS250.repository.EmployeeRepository;
-import UlsterCS250.viewModels.EmployeeVM;
+import UlsterCS250.requests.EmployeeVM;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;

--- a/vacation-planner-pro/src/main/resources/db/authdb_init.sql
+++ b/vacation-planner-pro/src/main/resources/db/authdb_init.sql
@@ -2,7 +2,7 @@
 CREATE EXTENSION IF NOT EXISTS citext;
 -- Creates the 'Employees' table with various fields
 CREATE TABLE Employees (
-    employee_id INTEGER PRIMARY KEY,
+    employee_id SERIAL PRIMARY KEY,
     username VARCHAR(255) UNIQUE NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
     email CITEXT UNIQUE NOT NULL,
@@ -15,30 +15,30 @@ CREATE TABLE Employees (
     years_of_service INTEGER
 );
 -- Employees Dummy Data
-INSERT INTO Employees (employee_id, username, password_hash, email, first_name, last_name, is_manager, is_active, create_time, last_login, years_of_service) VALUES
-    (0, 'johndoe', 'hashed_password1', 'johndoe@example.com', 'John', 'Doe', FALSE, TRUE, NOW(), NULL, 5),
-    (1, 'janedoe', 'hashed_password2', 'janedoe@example.com', 'Jane', 'Doe', TRUE, TRUE, NOW(), NULL, 8),
-    (2, 'bobsmith', 'hashed_password3', 'bobsmith@example.com', 'Bob', 'Smith', FALSE, TRUE, NOW(), NULL, 3),
-    (3, 'alicewhite', 'hashed_password4', 'alicewhite@example.com', 'Alice', 'White', FALSE, TRUE, NOW(), NULL, 2),
-    (4, 'tomblack', 'hashed_password5', 'tomblack@example.com', 'Tom', 'Black', TRUE, FALSE, NOW(), NULL, 10),
-    (5, 'sarahgreen', 'hashed_password6', 'sarahgreen@example.com', 'Sarah', 'Green', FALSE, TRUE, NOW(), NULL, 4),
-    (6, 'davidbrown', 'hashed_password7', 'davidbrown@example.com', 'David', 'Brown', FALSE, TRUE, NOW(), NULL, 1),
-    (7, 'emilyclark', 'hashed_password8', 'emilyclark@example.com', 'Emily', 'Clark', TRUE, TRUE, NOW(), NULL, 7),
-    (8, 'brianmiller', 'hashed_password9', 'brianmiller@example.com', 'Brian', 'Miller', FALSE, TRUE, NOW(), NULL, 5),
-    (9, 'chloewilson', 'hashed_password10', 'chloewilson@example.com', 'Chloe', 'Wilson', TRUE, TRUE, NOW(), NULL, 6);
+INSERT INTO Employees (username, password_hash, email, first_name, last_name, is_manager, is_active, create_time, last_login, years_of_service) VALUES
+    ('johndoe', 'hashed_password1', 'johndoe@example.com', 'John', 'Doe', FALSE, TRUE, NOW(), NULL, 5),
+    ('janedoe', 'hashed_password2', 'janedoe@example.com', 'Jane', 'Doe', TRUE, TRUE, NOW(), NULL, 8),
+    ('bobsmith', 'hashed_password3', 'bobsmith@example.com', 'Bob', 'Smith', FALSE, TRUE, NOW(), NULL, 3),
+    ('alicewhite', 'hashed_password4', 'alicewhite@example.com', 'Alice', 'White', FALSE, TRUE, NOW(), NULL, 2),
+    ('tomblack', 'hashed_password5', 'tomblack@example.com', 'Tom', 'Black', TRUE, FALSE, NOW(), NULL, 10),
+    ('sarahgreen', 'hashed_password6', 'sarahgreen@example.com', 'Sarah', 'Green', FALSE, TRUE, NOW(), NULL, 4),
+    ('davidbrown', 'hashed_password7', 'davidbrown@example.com', 'David', 'Brown', FALSE, TRUE, NOW(), NULL, 1),
+    ('emilyclark', 'hashed_password8', 'emilyclark@example.com', 'Emily', 'Clark', TRUE, TRUE, NOW(), NULL, 7),
+    ('brianmiller', 'hashed_password9', 'brianmiller@example.com', 'Brian', 'Miller', FALSE, TRUE, NOW(), NULL, 5),
+    ('chloewilson', 'hashed_password10', 'chloewilson@example.com', 'Chloe', 'Wilson', TRUE, TRUE, NOW(), NULL, 6);
 
 -- HalfDay table
 CREATE TABLE HalfDays (
-    half_day_id INTEGER PRIMARY KEY NOT NULL, --index of where this day is located
+    half_day_id SERIAL PRIMARY KEY NOT NULL, --index of where this day is located
     is_am BOOLEAN NOT NULL, -- what part of the day this half day is
     day_of_week_id INTEGER NOT NULL, -- the day of the week this half day is (Sunday=0, Monday=1...)
     start_date DATE NOT NULL, -- start date
     end_date DATE NOT NULL, -- end date
     is_work_day BOOLEAN NOT NULL -- whether or not company works this day
     );
-INSERT INTO HalfDays (half_day_id, is_am, day_of_week_id, start_date, end_date, is_work_day) VALUES
-    (0, TRUE, 1, '2024-01-01', '2024-01-01', TRUE),
-    (1, FALSE, 1, '2024-01-01', '2024-01-02', TRUE);
+INSERT INTO HalfDays (is_am, day_of_week_id, start_date, end_date, is_work_day) VALUES
+    (TRUE, 1, '2024-01-01', '2024-01-01', TRUE),
+    (FALSE, 1, '2024-01-01', '2024-01-02', TRUE);
 ------------------------------------------------------------------------------------
 
 -- EmployeeTimeOffs Table: Tracks employee time offs, allowing for half-day (AM/PM) and full-day tracking.
@@ -51,10 +51,21 @@ CREATE TABLE EmployeeTimeOffs (
     FOREIGN KEY (half_day_id) REFERENCES HalfDays(half_day_id) ON DELETE CASCADE -- Cascading delete with day deletion
     );
 
--- EmployeeTimeOffs Dummy Data
-INSERT INTO EmployeeTimeOffs (employee_id, half_day_id, reason) VALUES
-    (0, 0, 'Family vacation'),
-    (0, 1, 'Medical appointment');
+WITH inserted_employees AS (
+    SELECT employee_id
+    FROM Employees
+    WHERE username IN ('johndoe') -- Adjust usernames as needed
+)
+INSERT INTO EmployeeTimeOffs (employee_id, half_day_id, reason)
+SELECT employee_id, 1, 'Family vacation' FROM inserted_employees;
+
+WITH inserted_employees AS (
+    SELECT employee_id
+    FROM Employees
+    WHERE username IN ('janedoe') -- Adjust usernames as needed
+)
+INSERT INTO EmployeeTimeOffs (employee_id, half_day_id, reason)
+SELECT employee_id, 2, 'Medical appointment' FROM inserted_employees;
 
 -- VacationProfiles Table: Tracks individual vacation accruals and usage for each employee.
 CREATE TABLE VacationProfiles (


### PR DESCRIPTION
1. Addition of endpoint for calendar generation on the frontend. User inputs a digit from 1-12 for a month, and a four year digit for year, to generate a list of all days in that month, and vacations for each half-day.

2. Fix to the Employee DB table. Serial key in Employee table was removed in prior commit, probably to seed data to junction table. Removing Serial results in a bug when we attempt to post a new user. Our seed data conflicts with the attempt to add a new row (attempts to create a user with an id of 1, but finds a user with an id of 1 already there).
Current solution: Return Employee id key to serial, and use a CTE to seed data to EmployeeTimeOffs.